### PR TITLE
Added a composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name":         "cheddar-getter/client",
+    "type":         "library",
+    "description":  "The official PHP client for the CheddarGetter API",
+    "keywords":     ["CheddarGetter"],
+    "homepage":     "https://cheddargetter.com/developers",
+    "license":      "MIT",
+    "authors":      [
+        {
+            "name":  "Marc Guyer",
+            "email": "marc@cheddargetter.com"
+        }
+    ],
+    "recommend":    {
+        "ext-curl": "*"
+    },
+    "autoload":     {
+        "psr-0": { "CheddarGetter_": "" }
+    },
+    "target-dir": "CheddarGetter"
+}


### PR DESCRIPTION
This adds the config file needed to define the library as a Composer package.

Composer is the new dependency management tool which will become the official way to manage dependencies for Symfony2 soon: http://packagist.org/about-composer

The only need to make it easy to use the library with composer is to merge this file and then to register the repo in packagist (which could be done by anyone but it would be fair to let you do it so that you are marked as maintainer on the site). It will then crawl the repo regularly to reference new version automatically when you create a tag in the repo (and it will infer the version from the tag name if it follows the semantic versionning convention, avoiding to have to maintain the `version` key in the composer.json file): http://packagist.org/about
